### PR TITLE
Add Tus-Method-Override

### DIFF
--- a/protocol.md
+++ b/protocol.md
@@ -144,9 +144,9 @@ The `Tus-Max-Size` response header MUST be a non-negative integer indicating the
 allowed size of an entire upload in bytes. The Server SHOULD set this header if
 there is a known hard limit.
 
-#### Tus-Method-Override
+#### X-HTTP-Method-Override
 
-The `Tus-Method-Override` request header MUST be a string which MUST be
+The `X-HTTP-Method-Override` request header MUST be a string which MUST be
 interpreted as the request's method by the Server, if the header is presented.
 The actual method of the request MUST be ignored. The Client SHOULD use this
 header if its environment does not support the PATCH or DELETE methods.
@@ -652,7 +652,7 @@ The "X-" prefix for headers has been deprecated, see [RFC
 If you are dealing with HTTP proxies that strip/modify HTTP headers or can't
 handle `PATCH` requests properly, you should consider using HTTPS which will
 make it impossible for proxies to modify your requests and use the
-[`Tus-Method-Override`](#tus-method-override) header which allows you to use
+[`X-HTTP-Method-Override`](#x-http-method-override) header which allows you to use
 `POST` requests.
 
 If that is not an option for you, please reach out to us, we are open to

--- a/protocol.md
+++ b/protocol.md
@@ -144,6 +144,13 @@ The `Tus-Max-Size` response header MUST be a non-negative integer indicating the
 allowed size of an entire upload in bytes. The Server SHOULD set this header if
 there is a known hard limit.
 
+#### Tus-Method-Override
+
+The `Tus-Method-Override` request header MUST be a string which MUST be
+interpreted as the request's method by the Server, if the header is presented.
+The actual method of the request MUST be ignored. The Client SHOULD use this
+header if its environment does not support the PATCH or DELETE methods.
+
 ### Requests
 
 #### HEAD
@@ -644,7 +651,9 @@ The "X-" prefix for headers has been deprecated, see [RFC
 
 If you are dealing with HTTP proxies that strip/modify HTTP headers or can't
 handle `PATCH` requests properly, you should consider using HTTPS which will
-make it impossible for proxies to modify your requests.
+make it impossible for proxies to modify your requests and use the
+[`Tus-Method-Override`](#tus-method-override) header which allows you to use
+`POST` requests.
 
 If that is not an option for you, please reach out to us, we are open to
 defining a compatibility protocol extension.


### PR DESCRIPTION
This is a tus-specific version of the `X-HTTP-Method-Override` header to bing PATCH and DELETE methods to every platform. In reality most HTTP clients support these but not all. Examples are the ActionScript runtime inside the browser (http://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/flash/net/URLRequest.html#method) and the Java's HTTPUrlConnection.

@vayam @qsorix comments?