### PR TITLE
Add of the mandatory Upload-Offset in the PATCH server response

### DIFF
--- a/protocol.md
+++ b/protocol.md
@@ -101,6 +101,7 @@ Tus-Resumable: 1.0.0
 ```
 HTTP/1.1 204 No Content
 Tus-Resumable: 1.0.0
+Upload-Offset: 100
 ```
 
 ### Headers
@@ -342,6 +343,7 @@ Tus-Resumable: 1.0.0
 HTTP/1.1 204 No Content
 Upload-Expires: Wed, 25 Jun 2014 16:00:00 GMT
 Tus-Resumable: 1.0.0
+Upload-Offset: 100
 ```
 
 #### Headers
@@ -450,6 +452,7 @@ hello world
 ```
 HTTP/1.1 204 No Content
 Tus-Resumable: 1.0.0
+Upload-offset: 11
 ```
 
 ### Termination


### PR DESCRIPTION
In the tus protocol v1.0.0, is specified that the 
```The Server MUST acknowledge successful PATCH requests with the 204 No Content status. It MUST include the Upload-Offset header containing the new offset.```

In the different examples, the server responses did not include the Upload-Offset header. I added the header in the examples.