### PR TITLE
Extension to allow resetting an offset during a PATCH request

### DIFF
--- a/protocol.md
+++ b/protocol.md
@@ -661,6 +661,7 @@ HEAD /files/ab HTTP/1.1
 HTTP/1.1 200 OK
 Upload-Length: 11
 Upload-Concat: final;/files/a /files/b
+```
 
 ### Reset
 This extension allows clients to reset an upload by setting the offset of a 
@@ -676,7 +677,6 @@ reset the offset to the new value and SHOULD discard all stored data after that 
 The `Upload-Reset` value MUST be equal to the value of the `Upload-Offset` header in the request.
 If the `Upload-Reset` and `Upload-Offset` headers do not have the same value, then the server MUST 
 respond with `400 Bad Request` without modifying the upload resource.
-```
 
 ## FAQ
 

--- a/protocol.md
+++ b/protocol.md
@@ -661,6 +661,21 @@ HEAD /files/ab HTTP/1.1
 HTTP/1.1 200 OK
 Upload-Length: 11
 Upload-Concat: final;/files/a /files/b
+
+### Reset
+This extension allows clients to reset an upload by setting the offset of a 
+`PATCH` request to an offset less than the current server offset.  If the Server 
+supports this extension, it MUST add `reset` to the `Tus-Extension` header.
+
+#### Headers
+##### Upload-Reset
+The client MAY include a new offset with the header `Upload-Reset` during a `PATCH` request.  
+If the new offset value is less than or equal to the current server offset, the server MUST 
+reset the offset to the new value and SHOULD discard all stored data after that offset.  
+
+The `Upload-Reset` value MUST be equal to the value of the `Upload-Offset` header in the request.
+If the `Upload-Reset` and `Upload-Offset` headers do not have the same value, then the server MUST 
+respond with `400 Bad Request` without modifying the upload resource.
 ```
 
 ## FAQ


### PR DESCRIPTION
This is so that operating system controlled upload mechanisms (such as Apple's NSURLSession) that aggressively retry requests until they receive a response will continue to work even if there are wire failures.  Otherwise they cannot work with tus because the client will see an error response as a wire failure, and keep trying the PATCH request from zero repeatedly.  With this request, the concatenation mechanism can be implemented.