### PR TITLE
Make space in metadata optional for empty values

### DIFF
--- a/protocol.md
+++ b/protocol.md
@@ -294,7 +294,7 @@ Host: tus.example.org
 Content-Length: 0
 Upload-Length: 100
 Tus-Resumable: 1.0.0
-Upload-Metadata: filename d29ybGRfZG9taW5hdGlvbl9wbGFuLnBkZg==
+Upload-Metadata: filename d29ybGRfZG9taW5hdGlvbl9wbGFuLnBkZg==,is_confidential
 ```
 
 **Response:**
@@ -322,6 +322,8 @@ The `Upload-Metadata` request and response header MUST consist of one or more co
 key-value pairs. The key and value MUST be separated by a space. The key
 MUST NOT contain spaces and commas and MUST NOT be empty. The key SHOULD be
 ASCII encoded and the value MUST be Base64 encoded. All keys MUST be unique.
+The value MAY be empty. In these cases, the space, which would normally separate
+the key and the value, MAY be left out.
 
 #### Requests
 


### PR DESCRIPTION
The reasoning behind this change lays in tus/tus-js-client#41, to summarize:

If we have a metadata key-value pair with an empty value, we will get a value for the `Upload-Metadata` header such as: `"empty_value "`. Notice the space on the end of the string which normally separates the key and value. Usually, it should not be a problem that a header value ends with a space but in reality this is different, particularly in browsers.

For example, Chrome simply trims headers before sending a HTTP request to remove whitespace at the ends (https://cs.chromium.org/chromium/src/third_party/WebKit/Source/core/fetch/FetchUtils.cpp?sq=package:chromium&rcl=1471966011&l=209). On the other hand, Safari will refuse to add a header to a request which ends with a space (see https://github.com/request/request/issues/1951#issuecomment-163027168). Furthermore, such behavior is possibly not limited to browsers.

Basically, in both examples the clients are not able to send empty-valued metadata while being not compatible to the specification. Therefore, I suggest we make the separating space optional if the value is empty to circumvent these issues.

@kvz 
