### PR TITLE
remove misleading line

### DIFF
--- a/protocol.md
+++ b/protocol.md
@@ -256,7 +256,6 @@ allowed and the extensions for [Creation](#creation) and
 ```
 OPTIONS /files HTTP/1.1
 Host: tus.example.org
-Tus-Resumable: 1.0.0
 ```
 
 **Response:**


### PR DESCRIPTION
I found this line confusing.

Since the spec says `The Client SHOULD NOT include the Tus-Resumable header in the request and the Server MUST ignore the header`. I thought it'd make sense to rather remove that line from the example so it doesn't mislead anyone else as it did me. Please let me know if there's anything out of place. :)

**Question though:**
Does it mean the header `Tus-Resumable` should also be excluded from the response, since the server is expected to ignore it?