### PR TITLE
Client Tag Extension

### DIFF
--- a/protocol.md
+++ b/protocol.md
@@ -775,7 +775,7 @@ the resource. It MUST also be sent with a follow-up `HEAD` request used to retri
 
 ##### Upload-Tag-Secret
 
-The `Upload-Tag-Secret` MUST be a high-entropy cryptographic random [base64 alphabet](https://tools.ietf.org/html/rfc3986#section-2.3) string
+The `Upload-Tag-Secret` MUST be a high-entropy cryptographic random [base64 alphabet](https://tools.ietf.org/html/rfc4648#section-4) string
 with a minimum length of 48 characters and a maximum length of 256 characters.
 
 For unauthenticated uploads, Clients MUST send the `Upload-Tag-Secret` header

--- a/protocol.md
+++ b/protocol.md
@@ -743,7 +743,7 @@ To initiate an upload with Client Reference, Clients MUST include an `Upload-Cli
 header with the initial `POST` request (as specified in the [Creation](#creation) and
 [Creation With Upload](#creation-with-upload) extensions) made to the Upload URL.
 
-Clients can then send a `HEAD` request with the same `Upload-Client-Reference` header to the
+Clients can then send a [`HEAD`](#head) request with the same `Upload-Client-Reference` header to the
 Upload URL, which - upon success - MUST respond with the `200 OK` or `204 No Content`
 status, and the resource's URL in the response's `Location` header.
 
@@ -752,8 +752,8 @@ that indicates how many bytes have already been received by the server MAY also 
 
 Clients can then use the returned `Location` to resume the upload.
 
-If an `Upload-Client-Reference` is not or no longer known by the Server, it MUST respond to
-`HEAD` requests with the `404 Not Found` or `410 Gone` status.
+If an `Upload-Client-Reference` is unknown or no longer known by the Server, it MUST
+respond to `HEAD` requests with the `404 Not Found` or `410 Gone` status.
 
 If an `Upload-Client-Reference` is already in use for a different, ongoing upload, the Server
 MUST respond to the `POST` request initiating the upload with a `409 Conflict` status.
@@ -778,10 +778,10 @@ formats include:
 
 Vendor-specific formats MUST be prefixed with the vendor's name and formatted as `[vendor-name].[format-name]`.
 
-##### Tus-Client-Reference-Validity
+##### Tus-Client-Reference-TTL
 
 The Server MAY indicate how long the Client can use a  `Upload-Client-Reference` to reference an upload by
-including a `Tus-Client-Reference-Validity` header in response to an `OPTIONS` request, with one of the
+including a `Tus-Client-Reference-TTL` header in response to an `OPTIONS` request, with one of the
 following values:
 - `upload`: the  `Upload-Client-Reference` can be used until the upload completes, [expires](#expiration) or is [terminated](#termination).
 - `resource`: the `Upload-Client-Reference`  can be used even after the upload completed, until the uploaded resource is removed from the Server.

--- a/protocol.md
+++ b/protocol.md
@@ -775,23 +775,28 @@ the resource. It MUST also be sent with a follow-up `HEAD` request used to retri
 
 ##### Upload-Tag-Secret
 
-The `Upload-Tag-Secret` MUST be a high-entropy cryptographic random [base64 alphabet](https://tools.ietf.org/html/rfc4648#section-4) string
-with a minimum length of 48 characters and a maximum length of 256 characters.
+The `Upload-Tag-Secret` MUST be a high-entropy cryptographic random string, consisting
+of 48 to 256 characters from the [base64 alphabet](https://tools.ietf.org/html/rfc4648#section-4).
+That's 36 to 192 bytes encoded as base64.
 
 For unauthenticated uploads, Clients MUST send the `Upload-Tag-Secret` header
 alongside the `Upload-Tag` header with the `POST` request that creates the upload
 resource.
 
-Servers MUST return a `400 Bad Request` status for unauthenticated `POST` requests
+Servers MUST return a `403 Forbidden` status for unauthenticated `POST` requests
 that contain an `Upload-Tag` header, but do not also include a valid `Upload-Tag-Secret`
 header.
 
 For authenticated uploads, Servers MUST respond to `PATCH` and `HEAD` requests with
-a `404 Not Found` or `401 Unauthorized` status, if they include an `Upload-Tag` header
-identifying an upload resource that was created by a different user.
+a `404 Not Found` status, if they include an `Upload-Tag` header identifying an upload
+resource that was created by a different user.
 
 Clients MAY include an `Upload-Tag-Secret` header for authenticated uploads, but are
 not REQUIRED to do so.
+
+The `Upload-Tag-Secret` header MUST NOT be included with anything but `POST` requests
+creating a new upload resource. Servers receiving an `Upload-Tag-Secret` header with
+any other request MUST respond with a `400 Bad Request` status.
 
 ##### Upload-Tag-Challenge
 
@@ -802,7 +807,7 @@ subsequent `HEAD` and `PATCH` request that also contains an `Upload-Tag`.
 The value of `Upload-Tag-Secret` is defined as follows:
 
 ```
-Upload-Tag-Challenge = SHA256([Upload-Tag-Secret] + SHA256([Upload-Tag-Secret] + [Upload-Offset] + [Content-Length]))
+Upload-Tag-Challenge = SHA256([Upload-Tag-Secret] + SHA256([Upload-Offset] + [Upload-Tag-Secret] + [Content-Length]))
 ```
 
 For `HEAD` requests, `Upload-Tag-Challenge` is computed using `0` in place of `Upload-Offset`

--- a/protocol.md
+++ b/protocol.md
@@ -755,6 +755,9 @@ Clients can then use the returned `Location` to resume the upload.
 If an `Upload-Client-Identifier` is not or no longer known by the Server, it MUST respond to
 `HEAD` requests with the `404 Not Found` or `410 Gone` status.
 
+If an `Upload-Client-Identifier` is already used for another in-progress upload, the Server MUST
+respond to the  `POST` request initiating the upload with a `409 Conflict` status.
+
 #### Headers
 
 ##### Upload-Client-Identifier

--- a/protocol.md
+++ b/protocol.md
@@ -741,10 +741,10 @@ header.
 
 To initiate an upload with Client Identifier, Clients MUST include an `Upload-Client-Identifier`
 header with the initial `POST` request (as specified in the [Creation](#creation) and
-[Creation With Upload](#creation-with-upload) extensions).
+[Creation With Upload](#creation-with-upload) extensions) made to the Upload URL.
 
 Clients can then send a `HEAD` request with the same `Upload-Client-Identifier` header to the
-same URL on the Server, which - upon success - MUST respond with the `200 OK` or `204 No Content`
+Upload URL, which - upon success - MUST respond with the `200 OK` or `204 No Content`
 status, and the resource's URL in the response's `Location` header.
 
 A successful response MUST also contain the `Tus-Version` header. An `Upload-Offset` header that


### PR DESCRIPTION
The Client Identifier Extension to the tus protocol proposed here allows clients to resume an upload even if they did _not_ receive the response to the `creation` or `creation-with-upload` request with which they initiated the upload.

The mechanism for this is relatively simple:
- with the Client Identifier Extension, clients can generate a  _Client Identifier_ (typically a UUID) and send it alongside the initial `creation` or `creation-with-upload` request.
- if the connection is interrupted before the client receives the response with the URL of the created resource, the client can use the  _Client Identifier_ as a "backup" to retrieve the URL of the created resource.

Mobile client apps benefit of this extension in various ways:
- by taking advantage of `creation-with-upload`, complete uploads can be handed off to OS-managed background HTTP request queues (that continue to run when the apps themselves are already paused / suspended) for execution as soon as network connectivity is next available - without anxiety regarding the reliability of the connection
- if a `creation-with-upload` request doesn't complete, the Client Identifier Extension can be used to retrieve all information necessary to resume the upload right from the point where it was interrupted - not wasting a single byte (of expensive cellular data) of bandwidth to retransmit data that has already been transmitted. The upload will finish eventually - even on a very unreliable connection. And on a reliable connection, there's the opportunity for the upload to finish with maximum efficiency - with a single request.
- without the Client Identifier Extension, the only reliable way for mobile apps to ensure a piece of upload data is sent only once would be to limit itself to just the `creation` extension. Using that extension, however, generates a usage pattern of an initial (`creation`) request and an immediate (data upload) follow-on request - a usage pattern that is detected and penalized (with long delays) for background HTTP queues, by at least iOS.

In my proposal, I tried to match the language and style of the existing specification as closely as possible.

Feedback and questions welcome! 🙂