### PR TITLE
Add some red tape for metadata

### DIFF
--- a/protocol.md
+++ b/protocol.md
@@ -330,6 +330,10 @@ ASCII encoded and the value MUST be Base64 encoded. All keys MUST be unique.
 The value MAY be empty. In these cases, the space, which would normally separate
 the key and the value, MAY be left out.
 
+Since metadata can contain arbitrary binary values, Servers SHOULD
+carefully validate metadata values or sanitize them before using them
+as header values to avoid header smuggling.
+
 #### Requests
 
 ##### POST


### PR DESCRIPTION
I just noticed that simplistic implementations might be tempted to use the base64 decode of metadata values directly for headers, which could be used for smuggling.

E.g. consider something along the lines of

```
filetype dGV4dC9odG1sDQpDb250ZW50LUxlbmd0aDogMA0KDQpQT1NUIC9ldmlsL3JlcXVlc3QgSFRUUC8xLjENCkhvc3Q6IHNlY3JldC5pbnRlcm5hbC5ob3N0DQo=
```

if a TUS upload is turned into another HTTP/1.1 request.