### PR TITLE
Creation: Move follow-up logic out of header description.

### DIFF
--- a/protocol.md
+++ b/protocol.md
@@ -343,12 +343,15 @@ request a new upload resource. The request MUST include one of the following hea
 
 a) `Upload-Length` to indicate the size of an entire upload in bytes.
 
-b) `Upload-Defer-Length: 1` if upload size is not known at the time. Once it is
+b) `Upload-Defer-Length: 1` if upload size is not known at the time.
+If the `Upload-Defer-Length` header contains any other value
+than `1` the server should return a `400 Bad Request` status.
+
+After the length was deferred using `Upload-Defer-Length: 1`, once the length is
 known the Client MUST set the `Upload-Length` header in the next `PATCH` request.
 Once set the length MUST NOT be changed. As long as the length of the upload is
 not known, the Server MUST set `Upload-Defer-Length: 1` in all responses to
-`HEAD` requests. If the `Upload-Defer-Length` header contains any other value
-than `1` the server should return a `400 Bad Request` status.
+`HEAD` requests.
 
 If the Server supports deferring length, it MUST add `creation-defer-length` to
 the `Tus-Extension` header.

--- a/protocol.md
+++ b/protocol.md
@@ -347,8 +347,8 @@ b) `Upload-Defer-Length: 1` if upload size is not known at the time.
 If the `Upload-Defer-Length` header contains any other value
 than `1` the server should return a `400 Bad Request` status.
 
-After the length was deferred using `Upload-Defer-Length: 1`, once the length is
-known the Client MUST set the `Upload-Length` header in the next `PATCH` request.
+If the length was deferred using `Upload-Defer-Length: 1`, the Client MUST set
+the `Upload-Length` header in the next `PATCH` request, once the length is known.
 Once set the length MUST NOT be changed. As long as the length of the upload is
 not known, the Server MUST set `Upload-Defer-Length: 1` in all responses to
 `HEAD` requests.


### PR DESCRIPTION
I found this to be small improvement to text understandability:

---

It was slightly confusing that a lot of the logic of how the length eventually becomes known is written under a bullet point of

> "The request MUST include one of the following headers"

but other parts related to the same topic, such as `creation-defer-length` in the server's `Tus-Extension` header aren't.

With this change, the bullet point (b) is now focused on the header and what it is allowed to contain, and the logic is moved to the prose.