### PR TITLE
Clarify handling of empty uploads

### DIFF
--- a/protocol.md
+++ b/protocol.md
@@ -359,6 +359,10 @@ not known, the Server MUST set `Upload-Defer-Length: 1` in all responses to
 If the Server supports deferring length, it MUST add `creation-defer-length` to
 the `Tus-Extension` header.
 
+The `Upload-Length` header MAY be set to 0, indicating that the Client wants to
+upload an empty file. Such an upload is immediately complete after its creation without
+transferring data using `PATCH` requests.
+
 The Client MAY supply the `Upload-Metadata` header to add additional metadata to the
 upload creation request. The Server MAY decide to ignore or use this information to
 further process the request or to reject it. If an upload contains additional


### PR DESCRIPTION
Empty uploads with `Upload-Length: 0` were previously already allowed but this PR explicitly mentions them and provides more context on how to handle them.

This change is based on a question from https://github.com/tus/tus-resumable-upload-protocol/issues/196.